### PR TITLE
Strikes "Smart" from "Smart" Widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## MyUW Smart Widget Creator
+## MyUW Widget Creator
 
 ![https://travis-ci.org/UW-Madison-DoIT/myuw-smart-widget-creator.svg?branch=master](https://travis-ci.org/UW-Madison-DoIT/myuw-smart-widget-creator.svg?branch=master)
 
-This simple maven application is a development tool to create smart widgets without having the burden of trying to startup your own uPortal instance.
+This simple maven application is a development tool to create widgets without having the burden of trying to startup your own uPortal instance.
 
 ### Requirements
 
-If you just want to make use of it, [a smart widget creator instance is available online](https://tools.my.wisc.edu/widget-creator/).
+If you just want to make use of it, [a widget creator instance is available online](https://tools.my.wisc.edu/widget-creator/).
 
 This application assumes you are familiar with Maven, have it installed, and have a settings.xml
 appropriate for interacting with UW's [Maven Artifact Repository](https://wiki.doit.wisc.edu/confluence/pages/viewpage.action?spaceKey=ST&title=Maven+Repository+Manager).
@@ -31,7 +31,7 @@ Point your browser at http://localhost:8080 and you'll see the familiar My UW fr
 
 #### Permanant Home
 
-* [MyUW hosts a Smart Widget Creator instance among its supporting tools](https://tools.my.wisc.edu/widget-creator/)
+* [MyUW hosts a Widget Creator instance among its supporting tools](https://tools.my.wisc.edu/widget-creator/)
 
 #### What is this?
 


### PR DESCRIPTION
Remove the not-in-URLs usages of "smart" referring to widgets.
